### PR TITLE
chore(github-actions): update actions/checkout (v4 -> v7.0.0) and actions/cache (v4 -> v6.1.0)

### DIFF
--- a/.github/workflows/test-flux-diff.yaml
+++ b/.github/workflows/test-flux-diff.yaml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 1
         persist-credentials: false

--- a/.github/workflows/test-setup-repository-tools.yaml
+++ b/.github/workflows/test-setup-repository-tools.yaml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 1
         persist-credentials: false

--- a/actions/setup-repository-tools/action.yml
+++ b/actions/setup-repository-tools/action.yml
@@ -55,7 +55,7 @@ runs:
   using: composite
   steps:
   - name: Checkout current
-    uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     with:
       fetch-depth: ${{ inputs.current_fetch_depth }}
       path: current
@@ -70,7 +70,7 @@ runs:
     run: echo "cache_key=$(date +'%Y-%m')" >> "$GITHUB_OUTPUT"
 
   - name: Cache - mise
-    uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+    uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
     with:
       path: ~/.local/share/mise
       # yamllint disable-line rule:line-length
@@ -80,7 +80,7 @@ runs:
 
   - name: Cache - extra
     if: ${{ inputs.extra_cache_path != '' }}
-    uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+    uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
     with:
       path: ${{ inputs.extra_cache_path }}
       key: ${{ inputs.extra_cache_key }}-${{ steps.cache-key.outputs.cache_key }}


### PR DESCRIPTION
Pin actions/checkout and actions/cache to their latest major versions using full semver in the digest comment, matching renovate's pinGitHubActionDigests expectations.

- actions/checkout v4 -> v7.0.0: adds allow-unsafe-pr-checkout input (default false, no-op here since no pull_request_target/workflow_run triggers are used), migrates to node24 runtime.
- actions/cache v4 -> v6.1.0: migrates to node24 runtime and ESM, no input/output changes.

Both require Actions Runner >= v2.327.1, which is satisfied by GitHub-hosted ubuntu-24.04 runners already in use; no self-hosted runners exist in this repo, so no runs-on changes are needed.