### PR TITLE
docs: add CLAUDE.md, DESIGN.md, and per-action READMEs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+See [README.md](README.md) for what each action does and [DESIGN.md](DESIGN.md) for conventions and
+how release/renovate/testing fit together.
+
+## Repo layout
+
+- `actions/<name>/action.yml` — one composite action per directory. Each is self-contained: inputs,
+  outputs, and a `runs: using: composite` steps list, generally implemented as inline `shell: bash`.
+  Each directory also has its own `README.md` documenting that action's inputs/outputs/behavior in
+  detail — the root [README.md](README.md) only summarizes.
+- `ci/test-data/<name>/` — fixtures for that action's test workflow (e.g. before/after Flux manifest
+  trees, a sample `mise.toml`).
+- `.github/workflows/test-<name>.yaml` — one integration test workflow per action that has runtime
+  behavior worth exercising (`flux-diff`, `setup-repository-tools`). These invoke the action via
+  `uses: ./actions/<name>/` against the fixtures in `ci/test-data/`, run on PRs that touch the
+  action or its fixtures, and also on a weekly schedule to catch upstream drift (tool releases,
+  external API changes) between PRs.
+- `.github/workflows/lint.yaml`, `release.yaml`, `renovate.yaml` — repo-wide CI, all thin wrappers
+  around reusable workflows from `ppat/github-workflows@<pinned-sha>`. This repo owns none of the
+  linting/release/renovate logic itself — only the `with:`/`secrets:` wiring.
+
+## Commands
+
+This repo has no root-level toolchain manifest or build step — `pre-commit` (with yamllint,
+markdownlint-cli2, shellcheck, commitlint as hooks) is the only local tooling. Install it, then:
+
+```bash
+pre-commit install
+```
+
+Run all lint hooks against the whole repo (yamllint, markdownlint, shellcheck; commitlint hook only
+lints commit messages, not files):
+
+```bash
+pre-commit run --all-files
+```
+
+Run a single hook:
+
+```bash
+pre-commit run yamllint --all-files
+pre-commit run shellcheck --all-files
+pre-commit run markdownlint-cli2 --all-files
+```
+
+Lint a commit message locally:
+
+```bash
+echo "fix(dev-tools): bump astral-sh/uv" | npx commitlint
+```
+
+There is no build step. To exercise an action's actual runtime behavior, don't try to run its
+`shell: bash` steps locally — push a branch/PR that touches the action or its `ci/test-data/**`
+fixtures, which triggers the matching `test-<name>.yaml` workflow (`test-flux-diff.yaml`,
+`test-setup-repository-tools.yaml`) in GitHub Actions. These also run weekly and via
+`workflow_dispatch`.
+
+## Working in this repo
+
+- Each action in `actions/<name>/action.yml` is fully self-contained — inputs, outputs, and
+  composite steps in one file. When changing one, check whether a matching
+  `.github/workflows/test-<name>.yaml` + `ci/test-data/<name>/` fixture exists and update/extend it
+  rather than adding a separate ad hoc test path.
+- When changing an action's inputs, outputs, or behavior, update its `actions/<name>/README.md` in
+  the same change — that's the source of truth for that action's interface, not the root README.
+- Pin any new third-party Action reference to a commit SHA with the version as a trailing comment
+  (`uses: owner/repo@<sha> # vX.Y.Z`), and add a `# renovate: datasource=... depName=...` comment
+  above any tool version embedded directly in shell/YAML (see DESIGN.md) so Renovate can track it.
+- Commit messages must pass commitlint (`commitlint.config.js`): conventional-commit format, scope
+  must be one of `dev-tools`, `github-actions`, `renovate`, `release`, or empty, header ≤120 chars.
+  Commit messages, versioning, and `CHANGELOG.md` are otherwise fully automated by release-please —
+  don't hand-edit `CHANGELOG.md` or version numbers.
+- `lint.yaml`, `release.yaml`, and `renovate.yaml` call reusable workflows from
+  `ppat/github-workflows@<pinned-sha>` — there is very little logic to change in this repo's own
+  workflow files beyond the `with:`/`secrets:`/path-filter wiring and the pinned ref itself.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,40 @@
+# Design
+
+## Purpose
+
+This repo hosts standalone, reusable GitHub composite Actions consumed by workflows in
+[`ppat/github-workflows`](https://github.com/ppat/github-workflows) and by other `homelab-ops`/`ppat`
+repositories directly. Actions live here (rather than inline in workflow YAML) so they can be
+versioned, pinned by SHA, and tested independently of any one consuming repo.
+
+See [CLAUDE.md](CLAUDE.md) for repo layout.
+
+## Conventions used by the actions themselves
+
+- Actions favor plain `shell: bash` composite steps with `set -euo pipefail`, explicit input
+  validation with clear `ERROR:` messages, and `jq`/`gh` for GitHub API and JSON work, over
+  JavaScript/TypeScript actions. There is no build step for any action in this repo.
+- External tool versions pinned as action `default:` values (e.g. `mise_version` in
+  `setup-repository-tools`) or workflow `env:` (e.g. `UV_VERSION` in
+  `test-setup-repository-tools.yaml`) carry a `# renovate: datasource=... depName=...` comment
+  driving Renovate's custom regex manager (`.github/renovate.json`) — this is what lets Renovate
+  bump versions embedded in shell/YAML rather than a lockfile.
+- Third-party Actions (`actions/checkout`, `actions/cache`, `jdx/mise-action`, `docker://...`) are
+  pinned to a commit/digest with the version as a trailing comment, per
+  `helpers:pinGitHubActionDigests`/`docker:pinDigests` in the Renovate config.
+- `create-signed-commit` intentionally exits non-zero after a successful commit — the commit it
+  just created is expected to trigger the workflow's own re-run, which then finds no staged changes
+  and exits 0. Don't treat that as a bug.
+
+## Release & versioning
+
+Releases are automated by `release-please` (via `ppat/github-workflows`'s `release-please.yaml`,
+triggered from `release.yaml` on push to `main`). Conventional commit messages (enforced by
+commitlint, see below) drive version bumps and `CHANGELOG.md` generation. Consumers pin to a
+released tag (or commit SHA) of this repo when referencing `homelab-ops-actions/actions/<name>`.
+
+## Dependency updates
+
+Renovate (`.github/renovate.json`) runs on a schedule and via `renovate.yaml`, opening PRs to bump
+pinned Action SHAs and tool versions marked with `# renovate:` comments. `packageRules` excludes
+`ci/test-data/**` from updates since those fixtures are intentionally frozen for reproducible diffs.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # Homelab-Ops Actions
+
+A collection of reusable [GitHub composite Actions](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action)
+supporting CI/CD workflows across the `homelab-ops` and `ppat` GitHub organizations/repos.
+
+## Actions
+
+| Action | Description |
+| --- | --- |
+| [`actions/comment-on-pr`](actions/comment-on-pr/README.md) | Create or update a PR comment, keyed by a hidden `message_id` marker so repeat runs edit in place instead of piling up new comments. |
+| [`actions/create-signed-commit`](actions/create-signed-commit/README.md) | Commit staged changes to a branch via the GitHub GraphQL API (`createCommitOnBranch`) so the commit is signed by GitHub, instead of `git commit` + `git push`. |
+| [`actions/flux-diff`](actions/flux-diff/README.md) | Run [`flux-local diff`](https://github.com/allenporter/flux-local) between a before/after version of a Flux-managed Kubernetes manifest tree and expose the resulting patch. |
+| [`actions/setup-repository-tools`](actions/setup-repository-tools/README.md) | Checkout a repository and install its toolchain via [`mise`](https://mise.jdx.dev/), with caching. Used as the common setup step by reusable workflows in [`ppat/github-workflows`](https://github.com/ppat/github-workflows). |
+
+Each action's README documents its inputs, outputs, and a usage example in full.
+
+See [DESIGN.md](DESIGN.md) for how these actions are structured, tested, and released, and
+[CLAUDE.md](CLAUDE.md) for repo-specific guidance when working with Claude Code.

--- a/actions/comment-on-pr/README.md
+++ b/actions/comment-on-pr/README.md
@@ -1,0 +1,45 @@
+# comment-on-pr
+
+Create a new comment on a pull request, or update an existing one, keyed by a caller-supplied
+`message_id`.
+
+## How it works
+
+The action embeds a hidden `<!-- pr-comment-id: <message_id> -->` marker in the comment body, then
+searches existing PR comments for that marker on each run. If found, it `PATCH`es that comment in
+place; otherwise it creates a new one. This lets a workflow re-post updated content (e.g. a diff, a
+status) to the same comment across multiple runs instead of accumulating duplicates. Uses `gh api`
+and `jq` directly — no GitHub App/token exchange beyond the `token` input.
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `message` | yes | | Comment body |
+| `message_id` | yes | | Unique identifier used to find and update an existing comment |
+| `repository` | no | `${{ github.repository }}` | `owner/repo` |
+| `pr_number` | no | `${{ github.event.pull_request.number }}` | Pull request number |
+| `token` | yes | | GitHub token with write access to issues/PRs |
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `comment_id` | ID of the created/updated comment |
+| `comment_url` | URL of the created/updated comment |
+| `action_taken` | `created` or `updated` |
+
+## Example
+
+```yaml
+- uses: ppat/homelab-ops-actions/actions/comment-on-pr@<ref>
+  with:
+    message: |
+      `````diff
+      ${{ steps.some-step.outputs.diff }}
+      `````
+    message_id: "${{ github.event.pull_request.number }}/some-diff"
+    token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+See usage in [`.github/workflows/test-flux-diff.yaml`](../../.github/workflows/test-flux-diff.yaml).

--- a/actions/create-signed-commit/README.md
+++ b/actions/create-signed-commit/README.md
@@ -1,0 +1,47 @@
+# create-signed-commit
+
+Commit currently staged changes to a branch via the GitHub GraphQL `createCommitOnBranch` mutation,
+so the resulting commit is signed by GitHub rather than pushed with `git commit`/`git push`.
+
+## How it works
+
+1. Reads `git diff --cached --name-status -z` in `working_directory` and converts additions,
+   modifications, and renames into base64-encoded `fileChanges.additions`, and deletions/rename
+   sources into `fileChanges.deletions`.
+2. Resolves the branch's current `expectedHeadOid` via a GraphQL query so the mutation fails fast on
+   a stale base instead of silently overwriting concurrent commits.
+3. Calls `createCommitOnBranch` with the file changes, `commit_message`, and `expectedHeadOid`.
+4. **Exits 1 on a successful commit.** The commit just created is expected to trigger the calling
+   workflow's own re-run (e.g. via `push`), which will then find no staged changes and exit 0. This
+   is intentional, not a bug — don't "fix" it by changing the exit code.
+
+If there are no staged changes, the action exits 0 without attempting a commit.
+
+## Inputs
+
+| Input | Required | Description |
+| --- | --- | --- |
+| `commit_message` | yes | Commit headline |
+| `branch` | yes | Branch name to commit onto |
+| `repository` | yes | `owner/repo` |
+| `token` | yes | GitHub token with permission to write commits to `branch` |
+| `working_directory` | yes | Directory containing the git checkout with staged changes |
+
+## Outputs
+
+None.
+
+## Example
+
+```yaml
+- run: |
+    # ...make and `git add` changes...
+  working-directory: current
+- uses: ppat/homelab-ops-actions/actions/create-signed-commit@<ref>
+  with:
+    commit_message: "chore: update generated file"
+    branch: ${{ github.head_ref || github.ref_name }}
+    repository: ${{ github.repository }}
+    token: ${{ secrets.GITHUB_TOKEN }}
+    working_directory: current
+```

--- a/actions/flux-diff/README.md
+++ b/actions/flux-diff/README.md
@@ -1,0 +1,48 @@
+# flux-diff
+
+Run [`flux-local diff`](https://github.com/allenporter/flux-local) between a "before" and "after"
+version of a Flux-managed Kubernetes manifest tree (e.g. two checkouts, or a PR base vs. head) and
+expose the resulting unified diff as an output.
+
+## How it works
+
+Runs the `ghcr.io/allenporter/flux-local` Docker image's `diff <resource_type>` command against
+`path_before`/`path_after`, writing the result to `diff.patch`, then reads that file into the
+`diff` output. `strip_attrs`/`skip_params` default to stripping noisy, non-semantic fields (Helm
+chart checksums, versions) so diffs reflect real spec changes only.
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `resource_type` | yes | | Flux resource type to diff, e.g. `kustomization`, `helmrelease` |
+| `path_before` | yes | | Path to the "before" manifest tree |
+| `path_after` | yes | | Path to the "after" manifest tree |
+| `sources` | yes | | `--sources` value passed to `flux-local diff`, e.g. `name=path` |
+| `log_level` | no | `INFO` | `--log-level` for `flux-local` |
+| `skip_params` | no | `--skip-crds --skip-secrets` | Extra `--skip-*` flags |
+| `strip_attrs` | no | `helm.sh/chart,checksum/config,app.kubernetes.io/version,chart` | Fields to strip before diffing |
+| `other_params` | no | `""` | Any additional `flux-local diff` flags (e.g. `--api-versions`) |
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `diff` | Unified diff produced by `flux-local diff` (empty string if no changes) |
+
+## Example
+
+See [`.github/workflows/test-flux-diff.yaml`](../../.github/workflows/test-flux-diff.yaml) and the
+fixtures under [`ci/test-data/flux-diff/`](../../ci/test-data/flux-diff/) for a full working example,
+including piping the `diff` output into
+[`comment-on-pr`](../comment-on-pr/README.md).
+
+```yaml
+- uses: ppat/homelab-ops-actions/actions/flux-diff@<ref>
+  id: flux-diff
+  with:
+    resource_type: kustomization
+    path_before: before
+    path_after: after
+    sources: "my-source=./"
+```

--- a/actions/setup-repository-tools/README.md
+++ b/actions/setup-repository-tools/README.md
@@ -1,0 +1,52 @@
+# setup-repository-tools
+
+Checkout a repository (into `current/`) and install its toolchain via [`mise`](https://mise.jdx.dev/),
+with caching for both the mise installs and an optional extra path. This is the common first step
+used by reusable workflows in [`ppat/github-workflows`](https://github.com/ppat/github-workflows)
+before running lint/test/build steps against a checked-out repo.
+
+## How it works
+
+1. Checks out `current_repository`@`current_git_ref` into `current/`.
+2. Restores/saves a cache for `~/.local/share/mise`, keyed by year-month plus a hash of
+   `current/mise.toml` (so a new month or a changed `mise.toml` gets a fresh cache).
+3. Optionally restores/saves a second cache at `extra_cache_path` under `extra_cache_key`, for
+   tool-specific caches (e.g. package manager download caches) that aren't part of mise's own store.
+4. Runs `jdx/mise-action` to install tools, honoring `mise_ignore_cfg` (paths to exclude from mise's
+   config resolution) and an optional inline `mise_toml` (merged/overridden config, useful for
+   supplying tool versions from the calling workflow rather than committing them to the repo).
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `current_repository` | yes | | Repository to checkout, `owner/repo` |
+| `current_git_ref` | yes | | Ref to checkout |
+| `token` | yes | | Token for checkout and `jdx/mise-action` |
+| `current_fetch_depth` | no | `1` | `actions/checkout` `fetch-depth` |
+| `current_persist_credentials` | no | `false` | `actions/checkout` `persist-credentials` |
+| `current_dir` | no | `""` | Subdirectory of the checkout to use as mise's working directory |
+| `extra_cache_path` | no | `""` | Additional path to cache (skipped if empty) |
+| `extra_cache_key` | no | `""` | Cache key prefix for `extra_cache_path` |
+| `mise_ignore_cfg` | no | `""` | Path (relative to `current/`) to exclude via `MISE_IGNORED_CONFIG_PATHS` |
+| `mise_log_level` | no | `info` | `jdx/mise-action` log level |
+| `mise_toml` | no | `""` | Inline `mise.toml` contents passed to `jdx/mise-action` |
+| `mise_version` | no | pinned version (Renovate-tracked) | `jdx/mise-action` mise version |
+
+## Outputs
+
+None.
+
+## Example
+
+See [`.github/workflows/test-setup-repository-tools.yaml`](../../.github/workflows/test-setup-repository-tools.yaml)
+and [`ci/test-data/setup-repository-tools/mise.toml`](../../ci/test-data/setup-repository-tools/mise.toml)
+for a full working example, including supplying an inline `mise_toml`.
+
+```yaml
+- uses: ppat/homelab-ops-actions/actions/setup-repository-tools@<ref>
+  with:
+    current_git_ref: ${{ github.head_ref || github.ref }}
+    current_repository: ${{ github.repository }}
+    token: ${{ secrets.GITHUB_TOKEN }}
+```


### PR DESCRIPTION
Give Claude Code (and human contributors) a map of repo layout, conventions, and each action's inputs/outputs/behavior without duplicating detail across files.