### PR TITLE
fix: give setup-repository-tools extra cache a per-run key with restore-keys

### DIFF
--- a/.github/workflows/test-setup-repository-tools.yaml
+++ b/.github/workflows/test-setup-repository-tools.yaml
@@ -42,6 +42,8 @@ jobs:
         current_repository: ${{ github.repository }}
         current_dir: ci/test-data/setup-repository-tools
         token: ${{ secrets.GITHUB_TOKEN }}
+        extra_cache_path: ~/.cache/test-setup-repository-tools-extra
+        extra_cache_key: test-setup-repository-tools-extra
         mise_toml: |
           [tools]
           uv  = "${{ env.UV_VERSION }}"
@@ -57,3 +59,19 @@ jobs:
         mise ls
         yamllint --version
         which yamllint
+
+    - name: Test extra_cache_path accumulates across runs
+      shell: bash
+      # yamllint disable-line rule:indentation
+      run: |
+        # Exercises extra_cache_path/extra_cache_key (issue #155): appends this run's id to a
+        # marker file on every run. If the "Cache - extra" step regresses to an exact-hit-only
+        # key (no restore-keys / no per-run uniqueness), later runs restore the same snapshot
+        # forever and this log stops growing - inspect across runs to confirm it still does.
+        cache_dir=~/.cache/test-setup-repository-tools-extra
+        mkdir -p "$cache_dir"
+        echo "Marker log before this run:"
+        cat "$cache_dir/runs.log" 2>/dev/null || echo "(none - first run this month, or cache not yet populated)"
+        echo "${{ github.run_id }}-${{ github.run_attempt }}" >> "$cache_dir/runs.log"
+        echo "Marker log after this run:"
+        cat "$cache_dir/runs.log"

--- a/actions/setup-repository-tools/action.yml
+++ b/actions/setup-repository-tools/action.yml
@@ -83,7 +83,15 @@ runs:
     uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
     with:
       path: ${{ inputs.extra_cache_path }}
-      key: ${{ inputs.extra_cache_key }}-${{ steps.cache-key.outputs.cache_key }}
+      # A run-unique key means this always misses and saves at the end of the run, so
+      # accumulating caches (package manager download stores, etc.) actually get updated -
+      # actions/cache never re-saves under a key that already exists. restore-keys still
+      # scopes to the current month prefix, so the run starts from the latest same-month
+      # snapshot and the month boundary still rotates/discards the cache as intended.
+      # See https://github.com/ppat/homelab-ops-actions/issues/155.
+      key: ${{ inputs.extra_cache_key }}-${{ steps.cache-key.outputs.cache_key }}-${{ github.run_id }}
+      restore-keys: |
+        ${{ inputs.extra_cache_key }}-${{ steps.cache-key.outputs.cache_key }}-
 
   - name: Setup mise
     uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1


### PR DESCRIPTION
## Summary

- Fixes #155 — the "Cache - extra" step in `actions/setup-repository-tools/action.yml` keyed purely on `<extra_cache_key>-YYYY-MM` with no `restore-keys`. `actions/cache` is immutable per key, so within a given month the first run's save was the only one that ever landed — every later run that month exact-hit the same key and its own save step silently no-op'd, discarding whatever the cache had accumulated (pre-commit envs, `uv` downloads) since run #1.
- Monthly rotation is intentional (that's how the cache gets garbage-collected) and is preserved: the year-month segment stays in both `key` and the new `restore-keys` prefix, exactly matching the pattern the neighbouring "Cache - mise" step already uses. Only the within-month no-op save is fixed, by appending `${{ github.run_id }}` so every run's key is unique and a fresh save always lands, while `restore-keys` still pulls forward the latest same-month snapshot.
- Also wires `extra_cache_path`/`extra_cache_key` into `test-setup-repository-tools.yaml`, which previously didn't exercise that code path at all, plus a step that appends a run marker so future CI log inspection can catch a regression back to "log stops growing."

## Verification

Pushed this branch and ran the test workflow twice via `workflow_dispatch` (`gh workflow run`), inspecting the `actions/cache` step logs directly:

**Run 1** (`31206503752`) — no prior cache exists:
```
Cache not found for input keys: test-setup-repository-tools-extra-2026-08-31206503752, test-setup-repository-tools-extra-2026-08-
...
Cache saved with key: test-setup-repository-tools-extra-2026-08-31206503752
```

**Run 2** (`31206559214`) — triggered immediately after run 1 completed:
```
Cache hit for restore-key: test-setup-repository-tools-extra-2026-08-31206503752
Cache restored from key: test-setup-repository-tools-extra-2026-08-31206503752
```
Marker log before this run: `31206503752-1` (run 1's content, recovered via the `restore-keys` prefix fallback — not an exact-key hit).
Marker log after this run: `31206503752-1` / `31206559214-1` (appended).
```
Cache saved with key: test-setup-repository-tools-extra-2026-08-31206559214
```

This is the crux of the fix: run 2's primary key (unique via `run_id`) missed, `restore-keys` recovered run 1's snapshot, and — unlike the old behavior, where run 2 would have exact-hit the same bare `<key>-YYYY-MM` and its save step would have silently no-op'd — a fresh save landed under a new key. Monthly rotation is unchanged: once the month string rolls over, neither the primary key nor the `restore-keys` prefix will match this month's entries, same as the untouched, already-accepted mise cache step.

Both runs completed successfully end to end.

## Impact / blast radius

Confirmed the two real callers of `extra_cache_path`/`extra_cache_key` (`ppat/github-workflows`'s `lint-pre-commit.yaml`, and `ppat/homelab-ops-ansible`'s several workflows using `~/.cache/uv/`) both pass a plain fixed prefix (`pre-commit`, `uv`), not a content-addressed key — they are exactly the accumulating-cache shape this fixes and need no caller-side changes. No caller today uses a content-addressed `extra_cache_key`; if one existed, this change would make it re-save every run instead of skipping unchanged saves (still correct, just a bit more write traffic) — flagging this for awareness since the action is consumed estate-wide.

## Test plan

- [x] `pre-commit run --all-files` on the changed files (yamllint etc.)
- [x] Triggered `test-setup-repository-tools.yaml` twice via `workflow_dispatch` on this branch and inspected `actions/cache` logs directly (see above)
- [x] Extended `test-setup-repository-tools.yaml` to exercise `extra_cache_path`/`extra_cache_key`, closing a previously untested code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)